### PR TITLE
bug/#103 모달 이슈 해결

### DIFF
--- a/static/script/common/modal.js
+++ b/static/script/common/modal.js
@@ -116,7 +116,7 @@ window.addEventListener("resize", function () {
   let modals = document.querySelectorAll(".modal");
   modals.forEach(function (modal) {
     // 모달이 켜져있을때 모바일이면 block, 웹이면 flex
-    if (modal.style.display !== "none")
+    if (modal.style.display && modal.style.display !== "none")
       modal.style.display = isMobile ? "block" : "flex";
   });
 });


### PR DESCRIPTION
# 이슈내용

- 로그인 버튼을 클릭하지 않고 반응형을 위해 화면의 너비를 바꾸면 로그인 모달이 켜지는 이슈

# 원인

- 웹에서만 로그인, 회원가입 애니메이션 동작을 반영하기 위해 화면의 크기가 바뀌는 경우에 대한 이벤트 핸들러를 추가했다.
- 이때 모달이 켜져있을 경우 웹에서만 애니메이션이 적용되도록 modal.display 가 none 이 아닌 경우에 대한 코드를 작성했다.
- 다만 모달이 켜져있지 않으면 display 가 none 이 아니라 display 자체가 설정되어 있지 않아서 반응형시 항상 코드가 동작하고 있었다.