### PR TITLE
bug/#100-slack 상태 변경 불안정한 이슈

### DIFF
--- a/controller/CStudy.js
+++ b/controller/CStudy.js
@@ -134,7 +134,7 @@ exports.postRegister = async (req, res) => {
 
       // slack team2-week4-bot 채널로 스터디 생성 요청 알림
       await boltApp.client.chat.postMessage({
-        token: process.env.SLACK_BOT_TOKEN,
+        token: process.env.SLACK_BOT_TOKEN2,
         channel: process.env.CHANNEL_ID,
         blocks,
         text: "스터디 개설 요청",

--- a/slack.js
+++ b/slack.js
@@ -4,9 +4,9 @@ const { Study } = require("./models");
 let logLevel = LogLevel.INFO;
 
 const {
-  SLACK_BOT_TOKEN: token,
-  SLACK_APP_TOKEN: appToken,
-  SLACK_SIGNING_SECRET: signingSecret,
+  SLACK_BOT_TOKEN2: token,
+  SLACK_APP_TOKEN2: appToken,
+  SLACK_SIGNING_SECRET2: signingSecret,
 } = process.env;
 
 const boltApp = new App({
@@ -33,12 +33,10 @@ boltApp.action("approve", async ({ ack, body }) => {
         },
       }
     );
-    if (res) {
-      postMessage("[수정됨] 스터디 개설을 승낙했습니다.", body);
-    }
   } catch (error) {
     console.error(error);
   }
+  postMessage("[수정됨] 스터디 개설을 승낙했습니다.", body);
 });
 
 boltApp.action("reject", async ({ ack, body }) => {
@@ -46,17 +44,20 @@ boltApp.action("reject", async ({ ack, body }) => {
 
   console.log("거절됨");
 
-  await Study.update(
-    {
-      status: "REJECTED",
-    },
-    {
-      where: {
-        id: body.actions[0].value,
+  try {
+    await Study.update(
+      {
+        status: "REJECTED",
       },
-    }
-  );
-
+      {
+        where: {
+          id: body.actions[0].value,
+        },
+      }
+    );
+  } catch (error) {
+    console.error(error);
+  }
   postMessage("[수정됨] 스터디 개설을 거절했습니다.", body);
 });
 


### PR DESCRIPTION
# 이슈

- 슬랙 채널로 스터디 개설 신청 메세지는 가는데 액션으로 승낙 / 거절을 통해 상태변경 요청이 이전 버전의 배포상태와 중첩되어 제대로 인식되지 않는 문제 발생

# 해결

- 이전 배포상태가 남아있는 원인을 찾지 못해 슬랙봇, 승낙용 채널을 새로 생성

Close: #100 